### PR TITLE
fixing deprecated usage of @ in service arguments

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,6 @@ services:
         class: Oh\EmojiBundle\Service\EmojiConverter
     emoji.twig.extension:
         class: Oh\EmojiBundle\Extension\EmojiExtension
-        arguments: [@emoji.converter]
+        arguments: ["@emoji.converter"]
         tags:
             -  { name: twig.extension }


### PR DESCRIPTION
wrapping service argument with quotes to resolve deprecation errors in symfony 3
